### PR TITLE
Propose edits

### DIFF
--- a/eosio.unregd/ricardian contracts/eosio.unregd-regaccount-rc.md
+++ b/eosio.unregd/ricardian contracts/eosio.unregd-regaccount-rc.md
@@ -2,8 +2,11 @@
 
 ## Description
 
-The intent of the `{{ regaccount }}` action is to register an EOS account using the stored information (Ethereum address/balance) after verifying the submitted ETH signature.
+The intent of the `regaccount` action is to register an EOS account using the stored information {{ Ethereum address }} and {{ balance }} from the `eosio.unregd` contract, after verifying the submitted Ethereum {{ signature }}.
 
-As an authorized party I {{ signer }} wish to create an account {{ account }} accessible with EOS public key {{ eos_pubkey_str }} by submitting cryptographic proof {{ signature }} corresponding to the Ethereum address.
+As an authorized party, I {{ signer }} wish to create an account {{ account }} on the EOS chain with ID: aca376f206b8fc25a6ed44dbdc66547c36c6c33e3a119ffbeaef943642f0e906, accessible with EOS public key {{ eos_pubkey_str }} by submitting cryptographic proof {{ signature }} corresponding to the {{ Ethereum address }}.
 
-As signer I stipulate that, if I am not the beneficial owner of these tokens, I have proof that I’ve been authorized to take this action by their beneficial owner(s).
+As signer, I stipulate that if I am not the beneficial owner of these tokens, I have proof that I’ve been authorized to take this action by their beneficial owner(s).
+
+In case of dispute, all cases should be brought to the EOS Core Arbitration Forum at https://eoscorearbitration.io/.
+

--- a/eosio.unregd/ricardian contracts/eosio.unregd-regaccount-rc.md
+++ b/eosio.unregd/ricardian contracts/eosio.unregd-regaccount-rc.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-The intent of the `regaccount` action is to register an EOS account using the stored information {{ Ethereum address }} and {{ balance }} from the `eosio.unregd` contract, after verifying the submitted Ethereum {{ signature }}.
+The intent of the `regaccount` action is to register an EOS account using the stored information {{ Ethereum address }} and token balance from the `eosio.unregd` contract, after verifying the submitted Ethereum {{ signature }}.
 
 As an authorized party, I {{ signer }} wish to create an account {{ account }} on the EOS chain with ID: aca376f206b8fc25a6ed44dbdc66547c36c6c33e3a119ffbeaef943642f0e906, accessible with EOS public key {{ eos_pubkey_str }} by submitting cryptographic proof {{ signature }} corresponding to the {{ Ethereum address }}.
 


### PR DESCRIPTION
Line 5 - remove curly braces around `regaccount` as the curly braces are used to print a bit of information pulled from elsewhere. `regaccount` is the just the name of this contract.
Line 5 - also the Ethereum address and balance are both values that will be pulled.
Line 7 - Adding in the chain ID to show that the intent of the contract is to create an account here, and not on some other network. Give the full intention.
Line 11 - Added DR forum